### PR TITLE
updated default value for new_top_layer method

### DIFF
--- a/device_generators/device_gen.py
+++ b/device_generators/device_gen.py
@@ -66,7 +66,7 @@ class DeviceGenerator:
     
     def new_top_layer(self, thickness, *bnd_params, npts=10, 
         surfs_to_extrude=None, label=None, material=None, pdoping=0, 
-        ndoping=0, bnd_label=None, bnd_type=None):
+        ndoping=0, bnd_label="top", bnd_type=None):
         """ Generate a top layer and gate.
         
         Args:


### PR DESCRIPTION
Gave a default value for the boundary condition representing the top of the device.